### PR TITLE
handle if result is GLOBAL ARRAY but ref has $JOB

### DIFF
--- a/mumps/ewdVistARPC.m
+++ b/mumps/ewdVistARPC.m
@@ -128,8 +128,10 @@ RPCEXECUTE(TMP) ;
  ;s ^rob(ix,"tA1")=$g(tA1)
  X X  ; execute the routine
  ;s ^rob(ix,"executed")=""
- M @TMP@("result","value")=tResult
+ M @TMP@("result","value")=tResult 
  S @TMP@("result","type")=$$EXTERNAL^DILFD(8994,.04,,rpc("resultType"))
+ ;if returns data at tResult["$J" then won't beable to retrieve later. Problem is might be a LOT of data 
+ I @TMP@("result","type")="GLOBAL ARRAY" X "M @TMP@(""result"",""value"")="_tResult 
  S trash=$$success()
  Q "OK"
  ;


### PR DESCRIPTION
When returning value referenced by GLOBAL ARRAY.(ie: result is a global variable name)
Problem might be that returned reference has a $JOB in it.
Rob's code doesn't guarantee same $JOB for each RPC call with same session id.
need to return all data calculated because it might be killed off between two RPC Calls.
Actually for good security hygiene,code should kill off at end after call.

By the Way, there is no guarantee that tResult is defined, or that it refers to a defined global.